### PR TITLE
docs(release-level): release level ga should be indicated

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
   "client_documentation": "https://googleapis.dev/nodejs/policytroubleshooter/latest/",
   "api_id": "policytroubleshooter.googleapis.com",
   "distribution_name": "@google-cloud/policy-troubleshooter",
-  "release_level": "GA",
+  "release_level": "ga",
   "default_version": "v1",
   "language": "nodejs",
   "name_pretty": "IAM Policy Troubleshooter API",

--- a/README.md
+++ b/README.md
@@ -124,6 +124,12 @@ _Legacy Node.js versions are supported as a best effort:_
 This library follows [Semantic Versioning](http://semver.org/).
 
 
+This library is considered to be **General Availability (GA)**. This means it
+is stable; the code surface will not change in backwards-incompatible ways
+unless absolutely necessary (e.g. because of critical security issues) or with
+an extensive deprecation period. Issues and requests against **GA** libraries
+are addressed with the highest priority.
+
 
 
 


### PR DESCRIPTION
Fix typo in `.repo-metadata.json`.

Fixes #10
